### PR TITLE
Feature/Harvey/onboarding/assets 및 detail page API 활용하여 기본 정보 랜더

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-}
+  images: {
+    domains: [
+      "bafybeies3odi24wyk3e22rnautr57tiuk3b56nxrd53fxgtvr37abmz5j4.ipfs.cf-ipfs.com",
+    ],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,15 @@
+import "../styles/globals.css";
+import { theme } from "@closet-design-system/theme-connect";
+import { ThemeProvider } from "@emotion/react";
+
+function MyApp({ Component, pageProps }) {
+  return (
+    <>
+      <ThemeProvider theme={theme}>
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </>
+  );
+}
+
+export default MyApp;

--- a/pages/api/assets.ts
+++ b/pages/api/assets.ts
@@ -1,17 +1,14 @@
-/* eslint-disable import/no-anonymous-default-export */
-import type { NextApiRequest, NextApiResponse } from "next";
-import { ThirdwebSDK } from "@thirdweb-dev/sdk";
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ThirdwebSDK } from '@thirdweb-dev/sdk';
 
-const NETWORK: string = "ethereum";
-const AZUKI_SMARTCONTRACT_ADDRESS: string =
-  "0xED5AF388653567Af2F388E6224dC7C4b3241C544";
-const CLO_CERTI_SMARTCONTRACT_ADDRESS: string =
-  "0x0669E8C36635fce3f26cE510713ccA769ecF8B88";
+const NETWORK: string = 'ethereum';
+const AZUKI_SMARTCONTRACT_ADDRESS: string = '0xED5AF388653567Af2F388E6224dC7C4b3241C544';
+const CLO_CERTI_SMARTCONTRACT_ADDRESS: string = '0x0669E8C36635fce3f26cE510713ccA769ecF8B88';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const sdk = new ThirdwebSDK(NETWORK);
   const contract = await sdk.getContract(AZUKI_SMARTCONTRACT_ADDRESS);
-  if (req.method === "GET") {
+  if (req.method === 'GET') {
     if (req.query.tokenId) {
       const tokenId: number = Number(req.query.tokenId);
       const asset = await contract.erc721.get(tokenId);
@@ -20,9 +17,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       const assets = await contract.erc721.getAll();
       res.status(200).json({ assets });
     }
-  } else if (req.method === "POST") {
-    res.status(200).json({ message: "POST" });
+  } else if (req.method === 'POST') {
+    res.status(200).json({ message: 'POST' });
   } else {
-    res.status(500).json({ message: "wrong connection" });
+    res.status(500).json({ message: 'wrong connection' });
   }
 };

--- a/pages/assets.tsx
+++ b/pages/assets.tsx
@@ -1,0 +1,54 @@
+import type { NextPage } from 'next';
+import axios from 'axios';
+import Header from '../src/components/Header';
+import { NFT } from '@thirdweb-dev/sdk';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+
+const Assets: NextPage = ({ assets }: any) => {
+  const router = useRouter();
+  return (
+    <div>
+      <Header />
+      <div>
+        <div>
+          {assets.map((asset: any) => (
+            <div
+              className="asset-card"
+              key={asset.id}
+              onClick={() => {
+                router.push(
+                  {
+                    pathname: '/assets/[tokenId]',
+                    query: {
+                      tokenId: asset.metadata.id,
+                    },
+                  },
+                  '',
+                );
+              }}
+            >
+              <Image src={asset.metadata.image} alt="Asset" width="163.75" height="165.75" />
+              <div>
+                <h4>{asset.metadata.name}</h4>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const getServerSideProps = async () => {
+  const response = await axios.get('http://localhost:3000/api/assets');
+  const assets: NFT[] = response.data.assets;
+
+  return {
+    props: {
+      assets: assets,
+    },
+  };
+};
+
+export default Assets;

--- a/pages/assets/[tokenId].tsx
+++ b/pages/assets/[tokenId].tsx
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import Image from 'next/image';
+
+const Asset = ({ asset }: any) => {
+  return (
+    <div>
+      <h4>{asset.metadata.name}</h4>
+      <Image src={asset.metadata.image} alt="Asset" width="163.75" height="165.75" />
+    </div>
+  );
+};
+
+export const getServerSideProps = async (context: any) => {
+  const { tokenId } = context.query;
+  console.log('tokenId :: ', tokenId);
+  const response = await axios.get('http://localhost:3000/api/assets', {
+    params: {
+      tokenId: tokenId,
+    },
+  });
+  console.log('asset :: ', response.data.asset);
+
+  return {
+    props: {
+      asset: response.data.asset,
+    },
+  };
+};
+
+export default Asset;

--- a/src/components/GridBox.tsx
+++ b/src/components/GridBox.tsx
@@ -1,0 +1,6 @@
+import styles from "styles/TabBar.module.css";
+import { InfoIcon, Select } from "@closet-design-system/core-connect";
+
+export default function GridBox() {
+  return <div>GRID BOX</div>;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import SearchBox from "../components/SearchBox";
+import GridBox from "../components/GridBox";
+
+export default function Header() {
+  return (
+    <div>
+      <SearchBox />
+      <GridBox />
+    </div>
+  );
+}

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,0 +1,16 @@
+import { SearchIcon } from "@closet-design-system/core-connect";
+
+export default function SearchBox() {
+  return (
+    <div>
+      <div>
+        <input placeholder="Search by NFTs" />
+        <div>
+          <div>
+            <SearchIcon />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- assets API 활용하여 assets & detail 페이지에 기본 정보 노출 시킴
- assets 페이지
  - 기본 레이아웃 구성(SearchBar, GridBox, AssetCard)
  - router를 통해 AssetCard 클릭시, detail page로 이동
- detail 페이지
  - 전달 받은 tokenId를 활용하여 api 호출
  - 해당 asset의 기본 정도 노출

> - [X] FEATURE
> - [ ] FIX
> - [ ] HOTFIX

#### 테스트
- assets 페이지
  - ![image](https://github.com/TheXXne/connect-frontend-assignment3/assets/75402122/fb7d04b2-8e29-4788-a426-4685ee1e6f07)
- detail 페이지
  - ![image](https://github.com/TheXXne/connect-frontend-assignment3/assets/75402122/a4f50cf2-de83-4a97-b08f-f5a78b3df7d7)



